### PR TITLE
Remove declared GHC 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_cache:
   - rm -rfv $CABALHOME/packages/head.hackage
 matrix:
   include:
+    - compiler: ghc-8.10.4
+      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.10.4","cabal-install-3.0"]}}
     - compiler: ghc-8.8.1
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.8.1","cabal-install-3.0"]}}
     - compiler: ghc-8.6.4
@@ -35,8 +37,6 @@ matrix:
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.4.2","cabal-install-2.4"]}}
     - compiler: ghc-8.2.2
       addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.2.2","cabal-install-2.4"]}}
-    - compiler: ghc-8.0.2
-      addons: {"apt":{"sources":["hvr-ghc"],"packages":["ghc-8.0.2","cabal-install-2.4"]}}
 before_install:
   - HC=$(echo "/opt/$CC/bin/ghc" | sed 's/-/\//')
   - WITHCOMPILER="-w $HC"

--- a/derive-storable.cabal
+++ b/derive-storable.cabal
@@ -20,7 +20,7 @@ build-type:          Simple
 extra-source-files:  ChangeLog.md README.md
 
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==8.2.2, GHC==8.4.2, GHC==8.6.4, GHC==8.8.1
+tested-with:         GHC==8.2.2, GHC==8.4.2, GHC==8.6.4, GHC==8.8.1, GHC==8.10.4
 
 Flag sumtypes
   Description:   Enable support for non-recursive sum types.


### PR DESCRIPTION
Apparently 9dd9def9d7d6aeccac2ebaeab22c0398413be2de did something incompatible with 8.0 making CI permared.